### PR TITLE
Introduced build_from_config for proper serialization/deserialization

### DIFF
--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -394,6 +394,9 @@ class TCN(Layer):
         config['return_state'] = self.return_state
         return config
 
+@classmethod
+def build_from_config(cls, config):
+    return cls(**config)
 
 def compiled_tcn(num_feat,  # type: int
                  num_classes,  # type: int


### PR DESCRIPTION
This new functions makes it possible to save and load a trainned model with TCN layers from config saved with .keras or .weights.h5